### PR TITLE
Update code to not destroy all the resources

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const policyStatements = [{
+const logsPolicyStatements = [{
   Effect: 'Allow',
   Action: ['logs:CreateLogStream', 'logs:CreateLogGroup', 'logs:PutLogEvents'],
   Resource: [
@@ -20,12 +20,24 @@ class SimplifyDefaultExecRole {
   }
 }
 
+function removeLogGroupStatement(statements){
+  return statements.filter(function(statement){
+    if(statement.Action.includes('logs:CreateLogGroup')){
+      return false
+    }
+    if(statement.Action.includes('logs:PutLogEvents')){
+      return false
+    }
+    return true
+  });
+}
+
 function simplifyBaseIAMLogGroups(serverless) {
   const resourceSection = serverless.service.provider.compiledCloudFormationTemplate.Resources;
-
   for (const key in resourceSection) {
     if (key === 'IamRoleLambdaExecution') {
-      resourceSection[key].Properties.Policies[0].PolicyDocument.Statement = policyStatements;
+      const statements = removeLogGroupStatement(resourceSection[key].Properties.Policies[0].PolicyDocument.Statement);
+      resourceSection[key].Properties.Policies[0].PolicyDocument.Statement = logsPolicyStatements.concat(statements);
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nolram/serverless-simplify-default-exec-role-plugin",
+  "name": "@shelf/serverless-simplify-default-exec-role-plugin",
   "version": "0.0.3",
   "description": "serverless-simplify-default-exec-role-plugin",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@shelf/serverless-simplify-default-exec-role-plugin",
-  "version": "0.0.2",
+  "name": "@nolram/serverless-simplify-default-exec-role-plugin",
+  "version": "0.0.3",
   "description": "serverless-simplify-default-exec-role-plugin",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
- This modification is made to not remove all the statements (to be a not destructive change),
just to remove the logs:* statements and keep the others policies.

Example (Before):

```json
           "PolicyDocument": {
              "Version": "2012-10-17",
              "Statement": [
                {
                  "Effect": "Allow",
                  "Action": [
                    "logs:CreateLogStream",
                    "logs:CreateLogGroup",
                    "logs:PutLogEvents"
                  ],
                  "Resource": [
                    {
                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*"
                    }
                  ]
                }
              ]
            }
          }
```

Example (Now):
```json
         "PolicyDocument": {
              "Version": "2012-10-17",
              "Statement": [
                {
                  "Effect": "Allow",
                  "Action": [
                    "logs:CreateLogStream",
                    "logs:CreateLogGroup",
                    "logs:PutLogEvents"
                  ],
                  "Resource": [
                    {
                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*"
                    }
                  ]
                },
                {
                  "Effect": "Allow",
                  "Action": [
                    "s3:GetObject",
                    "s3:PutObject"
                  ],
                  "Resource": {
                    "Fn::Join": [
                      "",
                      [
                        "arn:aws:s3:::",
                        "REDACTED",
                        "/*"
                      ]
                    ]
                  }
                },
                ... MORE
```